### PR TITLE
feat: Use new public repo shopist-code-security-demo [K9VULN-2709]

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -10,7 +10,7 @@ resource "aws_db_instance" "shopist_mysql_db_dev" {
   tags = {
     "dd_git_file"           = "terraform/db.tf"
     "dd_git_org"            = "DataDog"
-    "dd_git_repo"           = "github.com/DataDog/shopist-infra-iac-demo"
+    "dd_git_repo"           = "github.com/DataDog/shopist-code-security-demo"
     "dd_git_resource_lines" = "1:17"
     "dd_resource_signature" = "resource.aws_db_instance.shopist_mysql_db"
   }

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -27,7 +27,7 @@ EOF
   tags = {
     dd_git_file               = "terraform/ec2.tf"
     dd_git_org                = "DataDog"
-    dd_git_repo               = "shopist-infra-iac-demo"
+    dd_git_repo               = "shopist-code-security-demo"
     dd_git_resource_signature = "resource.aws_launch_template.nginx-instance"
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "remediation_demo_bucket" {
   tags = {
     "dd_git_file"           = "terraform/main.tf"
     "dd_git_org"            = "DataDog"
-    "dd_git_repo"           = "github.com/DataDog/shopist-infra-iac-demo"
+    "dd_git_repo"           = "github.com/DataDog/shopist-code-security-demo"
     "dd_git_resource_lines" = "1:9"
   }
 }

--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -5,7 +5,7 @@ resource "aws_iam_policy" "iac-remediation-policy" {
   tags = {
     dd_git_file               = "terraform/policies.tf"
     dd_git_org                = "DataDog"
-    dd_git_repo               = "shopist-infra-iac-demo"
+    dd_git_repo               = "shopist-code-security-demo"
     dd_git_resource_signature = "resource.aws_iam_role.iac-remediation-policy"
   }
 }

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -5,7 +5,7 @@ resource "aws_iam_role" "iac-remediation" {
   tags = {
     dd_git_file               = "terraform/roles.tf"
     dd_git_org                = "DataDog"
-    dd_git_repo               = "shopist-infra-iac-demo"
+    dd_git_repo               = "shopist-code-security-demo"
     dd_git_resource_signature = "resource.aws_iam_role.iac-remediation"
   }
 }

--- a/terraform/users.tf
+++ b/terraform/users.tf
@@ -4,7 +4,7 @@ resource "aws_iam_user" "iac-remediation-user" {
   tags = {
     dd_git_file               = "terraform/users.tf"
     dd_git_org                = "DataDog"
-    dd_git_repo               = "shopist-infra-iac-demo"
+    dd_git_repo               = "shopist-code-security-demo"
     dd_git_resource_signature = "resource.aws_iam_user.iac-remediation-user"
   }
 }


### PR DESCRIPTION
We want to use to use public repo `shopist-code-security-demo` instead of internal repo `shopist-infra-iac-demo` as target for IaC one-click remediation demo flow.