### PR TITLE
Fix XXE vulnerability in ProductImport.kt

### DIFF
--- a/kotlin/xxe/ProductImport.kt
+++ b/kotlin/xxe/ProductImport.kt
@@ -16,6 +16,11 @@ class ProductImport {
     @PostMapping("/api/catalog/import-xml")
     fun importProductCatalog(@RequestBody xmlContent: String): Map<String, Any> {
         val factory = DocumentBuilderFactory.newInstance()
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false)
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        factory.isExpandEntityReferences = false
         val builder = factory.newDocumentBuilder()
         val doc: Document = builder.parse(InputSource(StringReader(xmlContent)))
         doc.documentElement.normalize()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"998da2b7-7acc-4523-b183-704253c291bf","source":"chat","resourceId":"8b27c7ba-5211-41b7-a368-d61ace5a033b","workflowId":"01978cd8-2c84-4986-895f-347825732ecc","codeChangeId":"01978cd8-2c84-4986-895f-347825732ecc","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST)

Fixed XXE (XML External Entity) vulnerability in the `importProductCatalog` method by configuring the `DocumentBuilderFactory` to disable external entities and DTD processing.

## Changes
- Added security features to `DocumentBuilderFactory` in the `importProductCatalog` method:
  - Disabled DOCTYPE declarations
  - Disabled external general entities
  - Disabled external parameter entities
  - Disabled loading external DTDs
  - Disabled entity reference expansion

## Testing/Validation
The fix follows security best practices for preventing XXE attacks by completely disabling external entity processing while maintaining XML parsing functionality.

---

PR by Bits - [View session in Datadog](https://demo.datadoghq.com/code/8b27c7ba-5211-41b7-a368-d61ace5a033b)

Comment @datadog to request changes