### PR TITLE
Add timeout to requests.get call

### DIFF
--- a/python/missing_timeout/missing_timeout.py
+++ b/python/missing_timeout/missing_timeout.py
@@ -3,7 +3,7 @@ import requests
 
 def get_product_from_api(product_id):
     try:
-        r = requests.get(f"https://api.provider.ext/products/{product_id}")
+        r = requests.get(f"https://api.provider.ext/products/{product_id}", timeout=5)
         return r.json()
     except requests.exceptions.RequestException as e:
         print(e)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9216e6dd-0395-43c7-8b8f-434e7bc81821","source":"chat","resourceId":"d6ccbacc-8b59-4bc8-a37c-63cc3c3947f1","workflowId":"035fa472-e3aa-4969-b251-171062998735","codeChangeId":"035fa472-e3aa-4969-b251-171062998735","sourceType":"code_security_sast"} -->
Code Security (SAST) • [View in Code Security (SAST)](https://demo.datadoghq.com/security/code-security/repositories/github.com%2Fdatadog%2Fshopist-code-security-demo/main/71bf44e0482bc6aa79385081195728c109b18402/code-vulnerabilities?query=%40git.repository.id%3Agithub.com%2Fdatadog%2Fshopist-code-security-demo%20%40git.branch%3Amain%20%40git.commit.sha%3A71bf44e0482bc6aa79385081195728c109b18402%20%40static_analysis.result.category%3Asecurity%20%40static_analysis.result.item_type%3Astatic_analysis_violation%20-%40static_analysis.rule.is_testing%3Atrue%20-%40static_analysis.result.confidence%3Alow%20%40static_analysis.result.language%3Apython&fromUser=false&index=cicodescan&staticAnalysisId=AwAAAZ0L-nlYVYDw1gAAABhBWjBMLWxmakFBQ1pPQW11Y2VDOEFBQUEAAAAkZjE5ZDBiZmEtNzk1OC00ZDEzLWEzYjQtZmQyODJhM2M3OTI1AAAAug&start=1773935983318&end=1774025910027&paused=false)

This PR addresses a security vulnerability in the `get_product_from_api` function where the `requests.get` call was missing a timeout parameter. Without a timeout, the request could hang indefinitely if the server is unresponsive, leading to potential denial-of-service risks.

**Changes made:**
- Added `timeout=5` to the `requests.get` call to ensure requests fail fast if the server does not respond within 5 seconds.

This aligns with security best practices by preventing indefinite blocking of HTTP requests.

---

PR by Bits - [View session in Datadog](https://demo.datadoghq.com/code/d6ccbacc-8b59-4bc8-a37c-63cc3c3947f1)

Comment @datadog to request changes