### PR TITLE
Fix SQL injection in product category query

### DIFF
--- a/php/sql_injection/product_queries.php
+++ b/php/sql_injection/product_queries.php
@@ -31,8 +31,10 @@ function getProductById($conn) {
 // VULN 3: Double-quoted string with variable interpolation in SQL (SQL Injection)
 function getProductsByCategory($conn, $categorySlug) {
     $pdo = new PDO("mysql:host=localhost;dbname=shopist_db", "shopist_user", "shopist_pass");
-    // Variable interpolated directly into SQL string — PDO provides no benefit here
-    $stmt = $pdo->query("SELECT p.* FROM products p JOIN categories c ON p.category_id = c.id WHERE c.slug = '$categorySlug' ORDER BY p.created_at DESC");
+    // Use prepared statement with parameter binding to prevent SQL injection
+    $stmt = $pdo->prepare("SELECT p.* FROM products p JOIN categories c ON p.category_id = c.id WHERE c.slug = :slug ORDER BY p.created_at DESC");
+    $stmt->bindParam(':slug', $categorySlug, PDO::PARAM_STR);
+    $stmt->execute();
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"17398c90-7660-470a-a674-37b254b2af4e","source":"chat","resourceId":"1fd1877d-e37a-4916-a40c-32dacc19500f","workflowId":"76704274-d823-4b7c-8c2f-17a73d33d248","codeChangeId":"76704274-d823-4b7c-8c2f-17a73d33d248","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST)

Fixed SQL injection vulnerability in the `getProductsByCategory` function by using prepared statements with parameter binding instead of direct string interpolation.

## Changes
- Replaced direct variable interpolation in SQL query with PDO prepared statement
- Added parameter binding using `:slug` placeholder
- Ensured proper parameter type specification (PDO::PARAM_STR)

## Testing/Validation
- Verified PHP syntax is valid with `php -l`
- Confirmed the fix follows secure coding practices for SQL queries
- The fix maintains the same functionality while eliminating the SQL injection vulnerability

---

PR by Bits - [View session in Datadog](https://demo.datadoghq.com/code/1fd1877d-e37a-4916-a40c-32dacc19500f)

Comment @datadog to request changes