### PR TITLE
Fix SQL injection vulnerability in UserQueries

### DIFF
--- a/swift/sql_injection/UserQueries.swift
+++ b/swift/sql_injection/UserQueries.swift
@@ -25,18 +25,17 @@ class UserQueries {
     func findUser(byUsername username: String) -> [String: Any]? {
         var result: [String: Any]? = nil
 
-        // Attacker input example: admin' OR '1'='1
-        let query = "SELECT id, username, email, role FROM users WHERE username = '\(username)'"
+        // Fixed: Use parameterized query to prevent SQL injection
+        let query = "SELECT id, username, email, role FROM users WHERE username = ?"
         var statement: OpaquePointer?
 
-        if sqlite3_exec(db, query, nil, nil, nil) == SQLITE_OK {
-            if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
-                if sqlite3_step(statement) == SQLITE_ROW {
-                    let id = sqlite3_column_int(statement, 0)
-                    let usernameCol = String(cString: sqlite3_column_text(statement, 1))
-                    let email = String(cString: sqlite3_column_text(statement, 2))
-                    result = ["id": id, "username": usernameCol, "email": email]
-                }
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, username, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(statement) == SQLITE_ROW {
+                let id = sqlite3_column_int(statement, 0)
+                let usernameCol = String(cString: sqlite3_column_text(statement, 1))
+                let email = String(cString: sqlite3_column_text(statement, 2))
+                result = ["id": id, "username": usernameCol, "email": email]
             }
         }
         sqlite3_finalize(statement)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d9c38946-5a8b-4ec1-a5e0-9f5a1de0efa1","source":"chat","resourceId":"19d09b8d-5da1-49fc-bec8-5c513a72ab04","workflowId":"1ce8a874-5b0e-4d14-a7a8-485915982012","codeChangeId":"1ce8a874-5b0e-4d14-a7a8-485915982012","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST)

Fixed SQL injection vulnerability in the `findUser(byUsername:)` function by implementing parameterized queries.

## Changes
- Replaced string interpolation with parameterized query using `?` placeholder
- Added `sqlite3_bind_text()` to safely bind the username parameter
- Removed unnecessary `sqlite3_exec()` call since we're using `sqlite3_prepare_v2()` directly

## Testing/Validation
The fix follows the same pattern as the safe reference implementation (`safeGetUser(byId:)`) in the same file, ensuring consistency and security. The parameterized approach treats user input as data rather than executable SQL code, preventing SQL injection attacks.

---

PR by Bits - [View session in Datadog](https://demo.datadoghq.com/code/19d09b8d-5da1-49fc-bec8-5c513a72ab04)

Comment @datadog to request changes