### PR TITLE
Fix SQL injection vulnerability in product queries

### DIFF
--- a/php/sql_injection/product_queries.php
+++ b/php/sql_injection/product_queries.php
@@ -28,11 +28,13 @@ function getProductById($conn) {
     return mysqli_fetch_assoc($result);
 }
 
-// VULN 3: Double-quoted string with variable interpolation in SQL (SQL Injection)
+// FIXED: Using prepared statement with parameter binding to prevent SQL injection
 function getProductsByCategory($conn, $categorySlug) {
     $pdo = new PDO("mysql:host=localhost;dbname=shopist_db", "shopist_user", "shopist_pass");
-    // Variable interpolated directly into SQL string — PDO provides no benefit here
-    $stmt = $pdo->query("SELECT p.* FROM products p JOIN categories c ON p.category_id = c.id WHERE c.slug = '$categorySlug' ORDER BY p.created_at DESC");
+    // Use prepared statement with parameter binding
+    $stmt = $pdo->prepare("SELECT p.* FROM products p JOIN categories c ON p.category_id = c.id WHERE c.slug = :slug ORDER BY p.created_at DESC");
+    $stmt->bindParam(':slug', $categorySlug, PDO::PARAM_STR);
+    $stmt->execute();
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e9106a1d-703a-41dd-8399-9ad6ece7161e","source":"chat","resourceId":"70b1381a-2d4f-40a7-adaa-a2dd283924f1","workflowId":"df56b117-bb98-4321-a5ee-883593736ffe","codeChangeId":"df56b117-bb98-4321-a5ee-883593736ffe","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST)

Fixed SQL injection vulnerability in the `getProductsByCategory` function by implementing proper parameter binding.

## Changes
- Replaced direct variable interpolation in SQL query with prepared statement
- Added parameter binding using `:slug` placeholder
- Ensured user input is treated as literal data, not executable SQL

## Testing/Validation
- The fix uses PDO prepared statements with named parameters
- Input is bound as a string parameter to prevent SQL injection
- Maintains the same functionality while eliminating the security vulnerability

---

PR by Bits - [View session in Datadog](https://demo.datadoghq.com/code/70b1381a-2d4f-40a7-adaa-a2dd283924f1)

Comment @datadog to request changes