### PR TITLE
Fix insecure CSRF token generation

### DIFF
--- a/php/weak_cryptography/random_tokens.php
+++ b/php/weak_cryptography/random_tokens.php
@@ -33,9 +33,8 @@ function generateEmailVerificationCode() {
 
 // VULN 3: rand() seeded with user ID for CSRF token — deterministic and forgeable (Weak Cryptography)
 function generateCsrfToken($userId) {
-    // Seeding with a known value makes the token sequence fully predictable
-    srand($userId);
-    $token = rand();
+    // Use cryptographically secure random number generation
+    $token = random_int(0, PHP_INT_MAX);
     return md5($token);
 }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4a972a2d-2024-45b2-af31-a3ddb0068c76","source":"chat","resourceId":"ebdb8541-eee1-4b28-b457-1eaf970be40a","workflowId":"36a2ebfb-95ab-48e9-8a4b-1e3b0d9fa693","codeChangeId":"36a2ebfb-95ab-48e9-8a4b-1e3b0d9fa693","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST)

Fixed security vulnerability in CSRF token generation by replacing insecure pseudo-random number generation with cryptographically secure random numbers.

## Changes
- Replaced `rand()` with `random_int()` in `generateCsrfToken()` function
- Removed insecure `srand($userId)` seeding that made tokens predictable
- Updated comment to reflect secure implementation

## Testing/Validation
- Verified PHP syntax is valid
- Confirmed the fix addresses the static analysis violation for pseudo-random number usage
- The change maintains the same function signature and return type (MD5 hash)
- Uses PHP's built-in `random_int()` function which is cryptographically secure

---

PR by Bits - [View session in Datadog](https://demo.datadoghq.com/code/ebdb8541-eee1-4b28-b457-1eaf970be40a)

Comment @datadog to request changes