### PR TITLE
Add Bits AI cookie FP

### DIFF
--- a/php/insecure_cookie/checkout_session_cookie.php
+++ b/php/insecure_cookie/checkout_session_cookie.php
@@ -1,0 +1,23 @@
+<?php
+
+function issueCheckoutSessionCookie($request) {
+    $sessionId = $request['session_id'] ?? bin2hex(random_bytes(16));
+    $expires = time() + 600;
+
+    setcookie(
+        'shopist_checkout_session',
+        $sessionId,
+        $expires,
+        '/checkout',
+        'shopist.example.com',
+        true,
+        false
+    );
+
+    return $sessionId;
+}
+
+if (($_POST['action'] ?? '') === 'start_checkout') {
+    $sessionId = issueCheckoutSessionCookie($_POST);
+    echo json_encode(['checkout_session' => $sessionId]);
+}

--- a/php/insecure_cookie/checkout_session_cookie.php
+++ b/php/insecure_cookie/checkout_session_cookie.php
@@ -21,3 +21,5 @@ if (($_POST['action'] ?? '') === 'start_checkout') {
     $sessionId = issueCheckoutSessionCookie($_POST);
     echo json_encode(['checkout_session' => $sessionId]);
 }
+
+// Touch this file to trigger a fresh scan after Bits AI context changes.


### PR DESCRIPTION
## Demo goal

Create a short Bits AI Memories demo using `php-security/cookie-http-only`. This keeps the flow on the standard evaluation path and uses a finding that looks high confidence before extra context.

## GIF flow

- Show Bits flagging `HttpOnly=false` in `php/insecure_cookie/checkout_session_cookie.php`
- Report the finding as a false positive
- Add the custom context below
- Push another commit so Bits re-evaluates with the new context
- Show the finding moving to low confidence

## FP report

`shopist_checkout_session` is a legacy name for a checkout UI flow id. It is not an auth cookie, not a server session, and not used for authorization or payment decisions. JavaScript must read it to restore checkout progress.

## Custom context

### Shopist checkout cookies

`shopist_checkout_session` is a client-readable checkout flow id.

It is safe for this cookie to have `HttpOnly=false` because it is not an auth cookie, not a server session, and not a security boundary. JavaScript reads it to restore checkout progress.

This does not apply to `session`, `auth`, `remember`, or any cookie used for identity, authorization, payment, or account access.

## Validation

Ran `datadog-static-analyzer static-analysis.datadog.yml -i . -u php/insecure_cookie/checkout_session_cookie.php -f sarif -o /tmp/shopist-checkout-cookie.sarif --print-violations --fail-on-any-violation none`
