### PR TITLE
Add self-service download endpoints

### DIFF
--- a/ruby/path_traversal/admin_export_download.rb
+++ b/ruby/path_traversal/admin_export_download.rb
@@ -2,6 +2,9 @@ require 'sinatra'
 
 EXPORT_DIR = '/var/exports/shopist'
 
+# Export files are generated nightly by the reporting job and retained
+# for 30 days.
+
 # Operator-only data export download. Served from the internal ops
 # dashboard, behind the same admin auth filter as the other /admin routes.
 before '/admin/*' do

--- a/ruby/path_traversal/admin_export_download.rb
+++ b/ruby/path_traversal/admin_export_download.rb
@@ -1,0 +1,15 @@
+require 'sinatra'
+
+EXPORT_DIR = '/var/exports/shopist'
+
+# Operator-only data export download. Served from the internal ops
+# dashboard, behind the same admin auth filter as the other /admin routes.
+before '/admin/*' do
+  halt 403 unless session[:operator_admin]
+end
+
+get '/admin/exports/download' do
+  # VULN: user-controlled filename read from disk (CWE-22).
+  name = params[:name]
+  File.read("#{EXPORT_DIR}/#{name}")
+end

--- a/ruby/path_traversal/admin_log_viewer.rb
+++ b/ruby/path_traversal/admin_log_viewer.rb
@@ -1,0 +1,16 @@
+require 'sinatra'
+
+LOG_DIR = '/var/log/shopist'
+
+# Internal ops log viewer. Mounted under the admin dashboard, which is
+# gated by the operator auth filter below, so only internal operators
+# can reach these routes.
+before '/admin/*' do
+  halt 403 unless session[:operator_admin]
+end
+
+get '/admin/logs' do
+  # VULN: user-controlled filename read from disk (CWE-22).
+  filename = params[:file]
+  File.read("#{LOG_DIR}/#{filename}")
+end

--- a/ruby/path_traversal/invoice_downloads.rb
+++ b/ruby/path_traversal/invoice_downloads.rb
@@ -1,0 +1,13 @@
+require 'sinatra'
+
+INVOICE_DIR = '/var/www/invoices'
+
+get '/invoices/download' do
+  # Reduce to a bare filename so any directory or ../ components are
+  # stripped before the read.
+  name = File.basename(params[:file])
+  # VULN (false positive): the scanner flags this interpolated read, but
+  # `name` has already been reduced to a basename, so traversal is not
+  # possible.
+  File.read("#{INVOICE_DIR}/#{name}")
+end

--- a/ruby/path_traversal/report_templates.rb
+++ b/ruby/path_traversal/report_templates.rb
@@ -1,0 +1,14 @@
+require 'sinatra'
+
+TEMPLATE_DIR = '/var/www/report_templates'
+ALLOWED_REPORTS = %w[sales inventory refunds tax].freeze
+
+get '/reports/generate' do
+  report = params[:report]
+  # Only a fixed set of known report names is ever accepted.
+  halt 400, 'Unknown report' unless ALLOWED_REPORTS.include?(report)
+  # VULN (false positive): the scanner flags this read, but `report` is
+  # constrained to the allowlist above, so it can never be an arbitrary
+  # path.
+  File.read("#{TEMPLATE_DIR}/#{report}.json")
+end


### PR DESCRIPTION
## Summary

Adds four Ruby path-injection findings to support the Bits Memories section of an upcoming demo video. Each of the first three is a genuine false positive under `ruby-security/path-injection`, matching a different safety pattern, an internal auth gate, `File.basename` reduction, and allowlist validation.

- Commit 1 adds the three findings above (the report set).
- Commit 2 adds a fourth finding (auth-gate pattern) that is intentionally left unreported. It's meant to be evaluated only after the three reports and the custom context below are in place, so its Bits reason should cite that context on screen.

## Follow-up steps (not part of this PR, done in the product UI)

1. Scan commit 1's SHA, confirm the three findings appear under `ruby-security/path-injection`.
2. Report all three as false positives:
   - `admin_log_viewer.rb`, "This route is served from the internal ops dashboard and sits behind the admin-only auth filter, so only internal operators can reach it."
   - `invoice_downloads.rb`, "The filename is passed through File.basename before the read, so any directory traversal components are stripped and only a bare filename remains."
   - `report_templates.rb`, "The report name is checked against a fixed allowlist of known reports before the read, so it can never be used to build an arbitrary path."
3. Add custom context on the `ruby-security/path-injection` rule ("Path handling conventions (Ruby)") describing the three patterns above.
4. Scan commit 2's SHA and confirm the fourth finding's Bits reason references the auth-gate convention.

## Test plan

- [ ] Confirm all four findings fire under `ruby-security/path-injection`
- [ ] Confirm the three FP reports land in the Bits Memories "False Positive Reports" tab
- [ ] Confirm the custom context saves on the rule
- [ ] Confirm the fourth finding's Bits reason cites the auth-gate convention
