### PR TITLE
Add allowlist-validated order sorting

### DIFF
--- a/php/sql_injection/order_sorting.php
+++ b/php/sql_injection/order_sorting.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Shopist - Sorted Order Report (query layer)
+ * DEMO FILE: Intentional false positive for the Datadog Code Security SAST demo.
+ * DO NOT USE IN PRODUCTION.
+ */
+
+// listOrdersSorted returns an org's orders ordered by $sortColumn.
+//
+// An ORDER BY target cannot be a bound query parameter, so $sortColumn is
+// concatenated into the SQL text. The org filter is passed as a bound
+// parameter.
+function listOrdersSorted($conn, $orgId, $sortColumn) {
+    $sql = "SELECT id, user_id, total, status FROM orders WHERE user_id = ? ORDER BY " . $sortColumn;
+
+    $stmt = mysqli_prepare($conn, $sql);
+    mysqli_stmt_bind_param($stmt, "i", $orgId);
+    mysqli_stmt_execute($stmt);
+    $result = mysqli_stmt_get_result($stmt);
+
+    $orders = [];
+    while ($row = mysqli_fetch_assoc($result)) {
+        $orders[] = $row;
+    }
+    return $orders;
+}

--- a/php/sql_injection/order_sorting_handler.php
+++ b/php/sql_injection/order_sorting_handler.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Shopist - Sorted Order Report (request handler)
+ * DEMO FILE: Intentional false positive for the Datadog Code Security SAST demo.
+ * DO NOT USE IN PRODUCTION.
+ */
+
+require_once __DIR__ . '/sort_allowlist.php';
+require_once __DIR__ . '/order_sorting.php';
+
+// buildSortedOrderReport is the only caller of listOrdersSorted. $requestedSort
+// is the raw sort field from an API request. It is mapped through
+// resolveSortColumn, and a field resolveSortColumn does not recognize is
+// rejected before the query runs.
+function buildSortedOrderReport($conn, $orgId, $requestedSort) {
+    $sortColumn = resolveSortColumn($requestedSort);
+    if ($sortColumn === null) {
+        throw new InvalidArgumentException("unsupported sort field");
+    }
+    return listOrdersSorted($conn, $orgId, $sortColumn);
+}
+
+// --- Route dispatcher ---
+$conn   = mysqli_connect("localhost", "shopist_user", "shopist_pass", "shopist_db");
+$action = $_GET['action'] ?? '';
+$orgId  = $_SESSION['user_id'] ?? 0;
+
+if ($action === 'sorted_orders') {
+    $requestedSort = $_GET['sort'] ?? 'date';
+    $orders = buildSortedOrderReport($conn, $orgId, $requestedSort);
+    header('Content-Type: application/json');
+    echo json_encode($orders);
+}

--- a/php/sql_injection/sort_allowlist.php
+++ b/php/sql_injection/sort_allowlist.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Shopist - Sort Field Allowlist
+ * DEMO FILE: Intentional false positive for the Datadog Code Security SAST demo.
+ * DO NOT USE IN PRODUCTION.
+ */
+
+// resolveSortColumn returns the SQL column mapped to a requested sort field, or
+// null when the field is not in the allowlist.
+function resolveSortColumn($field) {
+    $allowedSortColumns = [
+        'date'     => 'created_at',
+        'total'    => 'total',
+        'status'   => 'status',
+        'customer' => 'user_id',
+    ];
+    return $allowedSortColumns[$field] ?? null;
+}


### PR DESCRIPTION
## Summary

Adds an order-sorting report endpoint whose `ORDER BY` column is built by string concatenation, a genuine false positive under `php-security/sql-injection`.

- `order_sorting.php`, `listOrdersSorted` concatenates `$sortColumn` into the SQL text because an `ORDER BY` target can't be a bound parameter. The org filter is still passed as a bound parameter.
- `sort_allowlist.php`, `resolveSortColumn` maps a requested sort field to a fixed allowlist of column names, returning `null` for anything else.
- `order_sorting_handler.php`, `buildSortedOrderReport` is the only caller of `listOrdersSorted`, and it always resolves the sort field through the allowlist first, rejecting unrecognized fields before the query runs.

## Test plan

- [ ] Confirm the finding fires under `php-security/sql-injection` at `order_sorting.php` line 14
