### PR TITLE
[PD-69101] Update Go stdlib directive

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/shopist-code-security-demo/go
 
-go 1.16
+go 1.26.5
 
 require (
     // Web framework


### PR DESCRIPTION
<!-- dd-meta {"pullId":"93d023ef-546f-472a-89ec-45e853e68231","source":"chat","resourceId":"31275269-a080-4b7b-a9a9-d6d78a7f8271","workflowId":"25c83ebb-2199-4934-88a5-c6da9f3b1591","codeChangeId":"25c83ebb-2199-4934-88a5-c6da9f3b1591","sourceType":"code_security_sca"} -->
## Summary

Code Security (SCA) • [View in Code Security (SCA)](https://demo.datadoghq.com/security/code-security/sca?query=%40status%3Aopen%20%40package.scope%3Aproduction%20%40advisory.type%3Acomponent_with_known_vulnerability%20%40git.repository_id%3Agithub.com%2Fdatadog%2Fshopist-code-security-demo&column=title&detection=static&order=asc&panel_advisoryId=GO-2025-4008&panel_libraryName=stdlib&panel_libraryVersion=1.16)

Remediate the reported Go stdlib advisory GO-2025-4008 / CVE-2025-58189 by moving the Go module directive to the recommended safe version.

## Changes

- Updated go/go.mod from `go 1.16` to `go 1.26.5`.
- Left dependency scope limited to the reported Go module location.

## Testing/Validation

- `go mod verify` passed before changing the dependency graph: `all modules verified`.
- `go mod tidy` was attempted twice, but both runs failed while downloading the required Go 1.26.5 toolchain because the environment could not reach the Go module proxy storage endpoint: `dial tcp 142.251.179.207:443: connect: no route to host`.
- `go build ./...` was not run because the required toolchain download failed before module refresh/build validation could proceed.

---

PR by Bits - [View session in Datadog](https://demo.datadoghq.com/code/31275269-a080-4b7b-a9a9-d6d78a7f8271)

Comment @datadog to request changes