### PR TITLE
Remove hardcoded secrets from deploy script

### DIFF
--- a/secret_scanning/scripts/deploy.sh
+++ b/secret_scanning/scripts/deploy.sh
@@ -1,34 +1,50 @@
 #!/bin/bash
 # Shopist deployment script
-# WARNING: intentionally contains hardcoded secrets for Secret Scanning demo
+#
+# All credentials MUST be injected at runtime via the environment (e.g. from a
+# secrets manager, CI secret store, or Vault agent). This script contains NO
+# literal credentials. Do not hardcode secrets here.
+set -euo pipefail
 
-# AWS credentials
-export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
-export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-export AWS_DEFAULT_REGION="us-east-1"
+# Ensure a required environment variable is set and non-empty; otherwise abort.
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "ERROR: required environment variable '$name' is not set. " \
+         "Inject it at runtime from your secrets manager." >&2
+    exit 1
+  fi
+}
+
+# AWS credentials (expected to be provided by the runtime environment)
+require_env AWS_ACCESS_KEY_ID
+require_env AWS_SECRET_ACCESS_KEY
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 
 # Docker Hub login
-DOCKER_HUB_TOKEN="dckr_pat_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abc"
-echo "$DOCKER_HUB_TOKEN" | docker login --username shopist --password-stdin
+require_env DOCKER_HUB_TOKEN
+echo "$DOCKER_HUB_TOKEN" | docker login --username "${DOCKER_HUB_USERNAME:-shopist}" --password-stdin
 
 # GitHub token for pulling private packages
-GH_TOKEN="ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ123456789"
+require_env GH_TOKEN
 git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
 # Helm / Kubernetes deployment
-KUBE_TOKEN="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzaG9waXN0LWRlcGxveSIsImlhdCI6MTYwMDAwMDAwMH0.fake_signature_for_demo"
+require_env KUBE_TOKEN
 kubectl config set-credentials shopist-deploy --token="$KUBE_TOKEN"
 
 # Vault token for secrets
-VAULT_TOKEN="hvs.aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcde"
+require_env VAULT_TOKEN
 vault login "$VAULT_TOKEN"
 
 # Notify Slack
-SLACK_WEBHOOK="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+require_env SLACK_WEBHOOK
 curl -X POST "$SLACK_WEBHOOK" -d '{"text":"Shopist deployment started"}'
 
 # Run database migrations
-DATABASE_URL="postgresql://shopist_admin:Sup3rS3cr3tP@ssw0rd!@prod-db.shopist.internal:5432/shopist"
+require_env DATABASE_URL
 psql "$DATABASE_URL" -f migrations/latest.sql
 
 echo "Deployment complete"


### PR DESCRIPTION
## Summary
Refactored the deployment script to eliminate all hardcoded secrets and enforce runtime injection of credentials from secure sources. This improves security posture by ensuring sensitive values are never stored in version control.

## Key Changes
- **Removed all hardcoded credentials**: Deleted literal AWS keys, Docker Hub tokens, GitHub tokens, Kubernetes tokens, Vault tokens, Slack webhooks, and database URLs from the script
- **Added runtime validation**: Implemented `require_env()` helper function that validates required environment variables are set at runtime, with clear error messages directing users to inject credentials from a secrets manager
- **Updated documentation**: Added inline comments clarifying that all credentials must be injected at runtime (e.g., from secrets managers, CI secret stores, or Vault agents)
- **Improved script robustness**: Added `set -euo pipefail` for safer bash execution and proper error handling
- **Made configuration flexible**: Changed hardcoded defaults (e.g., Docker username, AWS region) to use environment variables with sensible fallbacks where appropriate

## Implementation Details
- The `require_env()` function checks if a variable is set and non-empty, printing a descriptive error message to stderr and exiting with code 1 if validation fails
- All credential-dependent operations now explicitly call `require_env` before use, making dependencies clear
- The script maintains the same functional behavior while shifting credential management responsibility to the deployment environment

https://claude.ai/code/session_01Nixw3VEy6FDzjCKrfJHoGs