### PR TITLE
Fix S3 bucket ACL security vulnerability

### DIFF
--- a/iac/terraform/s3.tf
+++ b/iac/terraform/s3.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket" "shopist_product_images" {
 # VULN 2: Public-read ACL exposes all product images to the internet
 resource "aws_s3_bucket_acl" "shopist_product_images_acl" {
   bucket = aws_s3_bucket.shopist_product_images.id
-  acl    = "public-read"
+  acl    = "private"
 }
 
 # VULN 3: No server-side encryption — order receipts stored in plaintext


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f937252c-c905-47ce-8379-426b7e8dcb4c","source":"chat","resourceId":"a89c059c-699a-4264-93d1-b6016a81376b","workflowId":"ebe6415f-433a-4ad4-9fd2-e966a7848826","codeChangeId":"ebe6415f-433a-4ad4-9fd2-e966a7848826","sourceType":"code_security_iac"} -->
## Summary

Code Security (IaC)

Fixed S3 bucket ACL that allowed read access to all users by changing from 'public-read' to 'private'.

## Changes
- Changed `acl` parameter from `"public-read"` to `"private"` in the `aws_s3_bucket_acl` resource for `shopist_product_images_acl`

## Testing/Validation
- Verified the change is focused only on the specific security vulnerability
- Confirmed the fix follows the remediation example provided
- Ensured no new security issues were introduced in the modified section

---

PR by Bits - [View session in Datadog](https://demo.datadoghq.com/code/a89c059c-699a-4264-93d1-b6016a81376b)

Comment @datadog to request changes