### PR TITLE
Upgrade Go stdlib directive

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/shopist-code-security-demo/go
 
-go 1.16
+go 1.26.6
 
 require (
     // Web framework


### PR DESCRIPTION
<!-- dd-meta {"pullId":"c36a36ef-b24c-4018-a306-5a3340f5f17e","source":"chat","resourceId":"0299a9c7-e649-46b9-b22e-191a7275ee65","workflowId":"9ddcaffc-d232-465f-8123-3789896c220a","codeChangeId":"9ddcaffc-d232-465f-8123-3789896c220a","sourceType":"code_security_sca"} -->
## Summary

Code Security (SCA) • [View in Code Security (SCA)](https://demo.datadoghq.com/security/code-security/sca?column=score&order=desc&panel_advisoryId=GO-2025-4008&panel_libraryName=stdlib&panel_libraryVersion=1.16)

Upgrade the Go module directive for the Shopist Go demo module to remediate GO-2025-4008 / CVE-2025-58189 in the Go standard library.

## Changes
- Updated go/go.mod from Go 1.16 to Go 1.26.6.

## Testing/Validation
- Ran `go mod verify` before changing the dependency graph: passed with `all modules verified`.
- Attempted `go mod tidy` twice, but both attempts failed while downloading `go1.26.6` from the Go toolchain/module storage endpoint because the sandbox has no route to host.
- Attempted `git fetch origin main` twice as requested before finishing, but both attempts failed with HTTP 422 from the sandbox proxy.

---

PR by Bits - [View session in Datadog](https://demo.datadoghq.com/code/0299a9c7-e649-46b9-b22e-191a7275ee65)

Comment @datadog to request changes